### PR TITLE
Fixed Mocha and Jasmine npm test scripts.

### DIFF
--- a/Jasmine/package.json
+++ b/Jasmine/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-      "test": "node_modules\\.bin\\jasmine-node tests"
+      "test": "jasmine-node tests"
   },
   "dependencies": {},
   "devDependencies": {

--- a/Mocha/package.json
+++ b/Mocha/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "test": "node_modules\\.bin\\mocha"
+    "test": "mocha tests"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Removed the "node_modules//.bin//" from the npm scripts because npm
scripts automatically look there first for binaries. Also told Mocha where
to find the tests so it would actually run.
