### PR TITLE
Add folder tests as argument, since by default singular 'test' is expected

### DIFF
--- a/Mocha/package.json
+++ b/Mocha/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "test": "node_modules\\.bin\\mocha"
+    "test": "node_modules\\.bin\\mocha tests"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
I have just tried the tests and realized that commands
npm i
npm test
is enough for Jasmine and qUnit, but not enough for Mocha - the reason - Mocha expects tests to be in folder 'test', but not 'tests'
